### PR TITLE
I adore my 64, my XPDO-64

### DIFF
--- a/xpdo.class.php
+++ b/xpdo.class.php
@@ -1387,7 +1387,7 @@ class xPDO {
      */
     protected function _log($level, $msg, $target= '', $def= '', $file= '', $line= '') {
         if (empty ($target)) {
-            $target =& $this->logTarget;
+            $target = $this->logTarget;
         }
         $targetOptions = array();
         if (is_array($target)) {


### PR DESCRIPTION
Now with topic branch goodness...

This fixes the bug where non-default logging settings would only be used on the first call to log(), then would revert to default. For "proof" script and discussion, see http://bugs.modx.com/browse/XPDO-64

It's an easy fix, where perhaps a little more code or restructuring could get around the potential copy-on-update of the ->logTarget property (e.g. where $target is not explicitly passed to _log() and ->logTarget is an array). IMO, the memory/performance effects of this are not worth worrying about.
